### PR TITLE
Adds a javadsl (sbt) example on setting up CORS

### DIFF
--- a/cors/cors-java/.editorconfig
+++ b/cors/cors-java/.editorconfig
@@ -1,0 +1,12 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=true
+trim_trailing_whitespace = true
+indent_style=space
+indent_size=2
+
+
+[*.java]
+indent_style=space
+indent_size=4

--- a/cors/cors-java/.sbtopts
+++ b/cors/cors-java/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms512M
+-J-Xmx4096M
+-J-Xss2M
+-J-XX:MaxMetaspaceSize=1024M

--- a/cors/cors-java/LICENSE
+++ b/cors/cors-java/LICENSE
@@ -1,0 +1,15 @@
+This software is licensed under the Apache 2 license, quoted below.
+
+Copyright 2016 Lightbend Inc. [http://www.lightbend.com]
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    [http://www.apache.org/licenses/LICENSE-2.0]
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.

--- a/cors/cors-java/README.md
+++ b/cors/cors-java/README.md
@@ -1,0 +1,9 @@
+# CORS recipe for Lagom's Javadsl
+
+
+```
+curl -H "Access-Control-Request-Method: GET" \
+        -H "Access-Control-Request-Headers: origin, x-requested-with" \
+        -H "Origin: http://www.some-domain.com"  \
+        -X OPTIONS http://localhost:9000/api/hello/123 -v        
+```

--- a/cors/cors-java/README.md
+++ b/cors/cors-java/README.md
@@ -1,5 +1,24 @@
 # CORS recipe for Lagom's Javadsl
 
+In order to enable CORS on a Lagom service the following steps are required:
+
+1. include `filters` as a dependency on your `-impl` project. `filters` is a package provided by Play Framework.
+2. Create a class that implements `DefaultHttpFilters` and inject Play's `CORSFilter`
+3. Register that newly created class on your `application.conf` using: `play.http.filters = "com.your.package.YourFilterClassName"`
+4. Finally, add an ACL on your `Service.Descriptor` matching the `OPTIONS` method for the paths you are exposing on your Service Gateway.
+
+## Testing the recipe
+
+
+You can test this recipe using 2 separate terminals.
+
+On one terminal start the service:
+
+```
+sbt runAll
+```
+
+On a separate terminal, use `curl` to trigger a pre-flight request:
 
 ```
 curl -H "Access-Control-Request-Method: GET" \
@@ -7,3 +26,11 @@ curl -H "Access-Control-Request-Method: GET" \
         -H "Origin: http://www.some-domain.com"  \
         -X OPTIONS http://localhost:9000/api/hello/123 -v        
 ```
+
+Note how the request uses the `OPTIONS` method and targets the [Lagom Service Gateway](https://www.lagomframework.com/documentation/1.3.x/java/ServiceLocator.html) (`localhost:9000`).
+
+## More resources
+
+This topic has been discussed in the Lagom Mailing List [a](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/lagom-framework/_3Hjvp18NNU/ygu8Pa5wAQAJ) [few](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/lagom-framework/7YZccqRUS4g/HNMykAiGBAAJ) [times](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/lagom-framework/3y0wgIMillE/ItT1rPDfBgAJ), if this recipe doesn't resolve your doubts, feel free to ask for help in the community.
+
+You will also find the [Play Framework documentation](https://playframework.com/documentation/2.5.x/CorsFilter) on the topic quite useful. 

--- a/cors/cors-java/build.sbt
+++ b/cors/cors-java/build.sbt
@@ -1,0 +1,26 @@
+organization in ThisBuild := "com.lightbend.lagom.recipes"
+version in ThisBuild := "1.0-SNAPSHOT"
+
+// the Scala version that will be used for cross-compiled libraries
+scalaVersion in ThisBuild := "2.11.8"
+
+lazy val `cors-java` = (project in file("."))
+  .aggregate(`cors-java-api`, `cors-java-impl`)
+
+lazy val `cors-java-api` = (project in file("cors-java-api"))
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomJavadslApi
+    )
+  )
+
+lazy val `cors-java-impl` = (project in file("cors-java-impl"))
+  .enablePlugins(LagomJava)
+  .settings(
+    libraryDependencies ++= Seq(
+    )
+  )
+  .dependsOn(`cors-java-api`)
+
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false

--- a/cors/cors-java/build.sbt
+++ b/cors/cors-java/build.sbt
@@ -18,6 +18,7 @@ lazy val `cors-java-impl` = (project in file("cors-java-impl"))
   .enablePlugins(LagomJava)
   .settings(
     libraryDependencies ++= Seq(
+      filters
     )
   )
   .dependsOn(`cors-java-api`)

--- a/cors/cors-java/cors-java-api/src/main/java/com/lightbend/lagom/recipes/corsjava/api/CorsjavaService.java
+++ b/cors/cors-java/cors-java-api/src/main/java/com/lightbend/lagom/recipes/corsjava/api/CorsjavaService.java
@@ -6,7 +6,9 @@ package com.lightbend.lagom.recipes.corsjava.api;
 import akka.NotUsed;
 import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.ServiceAcl;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.transport.Method;
 
 import static com.lightbend.lagom.javadsl.api.Service.named;
 import static com.lightbend.lagom.javadsl.api.Service.pathCall;
@@ -22,7 +24,11 @@ public interface CorsjavaService extends Service {
     default Descriptor descriptor() {
         return named("corsjava").withCalls(
             pathCall("/api/hello/:id", this::hello)
-        ).withAutoAcl(true);
+        ).withAutoAcl(
+            true
+        ).withServiceAcls(
+            ServiceAcl.methodAndPath(Method.OPTIONS, "/api/hello/.*")
+        );
     }
 
 }

--- a/cors/cors-java/cors-java-api/src/main/java/com/lightbend/lagom/recipes/corsjava/api/CorsjavaService.java
+++ b/cors/cors-java/cors-java-api/src/main/java/com/lightbend/lagom/recipes/corsjava/api/CorsjavaService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.recipes.corsjava.api;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+
+import static com.lightbend.lagom.javadsl.api.Service.named;
+import static com.lightbend.lagom.javadsl.api.Service.pathCall;
+
+public interface CorsjavaService extends Service {
+
+    /**
+     * Example: curl http://localhost:9000/api/hello/Alice
+     */
+    ServiceCall<NotUsed, String> hello(String id);
+
+    @Override
+    default Descriptor descriptor() {
+        return named("corsjava").withCalls(
+            pathCall("/api/hello/:id", this::hello)
+        ).withAutoAcl(true);
+    }
+
+}

--- a/cors/cors-java/cors-java-impl/src/main/java/com/lightbend/lagom/recipes/corsjava/impl/CorsjavaModule.java
+++ b/cors/cors-java/cors-java-impl/src/main/java/com/lightbend/lagom/recipes/corsjava/impl/CorsjavaModule.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.recipes.corsjava.impl;
+
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+import com.lightbend.lagom.recipes.corsjava.api.CorsjavaService;
+
+/**
+ * The module that binds the CorsjavaService so that it can be served.
+ */
+public class CorsjavaModule extends AbstractModule implements ServiceGuiceSupport {
+  @Override
+  protected void configure() {
+    bindService(CorsjavaService.class, CorsjavaServiceImpl.class);
+  }
+}

--- a/cors/cors-java/cors-java-impl/src/main/java/com/lightbend/lagom/recipes/corsjava/impl/CorsjavaServiceImpl.java
+++ b/cors/cors-java/cors-java-impl/src/main/java/com/lightbend/lagom/recipes/corsjava/impl/CorsjavaServiceImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.recipes.corsjava.impl;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.recipes.corsjava.api.CorsjavaService;
+
+import javax.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Implementation of the CorsjavaService.
+ */
+public class CorsjavaServiceImpl implements CorsjavaService {
+
+
+  @Inject
+  public CorsjavaServiceImpl() {
+  }
+
+  @Override
+  public ServiceCall<NotUsed, String> hello(String id) {
+    return request -> CompletableFuture.completedFuture(id);
+  }
+
+
+}

--- a/cors/cors-java/cors-java-impl/src/main/java/com/lightbend/lagom/recipes/corsjava/impl/MyCORSFilter.java
+++ b/cors/cors-java/cors-java-impl/src/main/java/com/lightbend/lagom/recipes/corsjava/impl/MyCORSFilter.java
@@ -1,0 +1,14 @@
+package com.lightbend.lagom.recipes.corsjava.impl;
+
+import play.filters.cors.CORSFilter;
+import play.http.DefaultHttpFilters;
+
+import javax.inject.Inject;
+
+// See https://playframework.com/documentation/2.5.x/CorsFilter
+public class MyCORSFilter extends DefaultHttpFilters {
+    @Inject
+    public MyCORSFilter(CORSFilter corsFilter) {
+        super(corsFilter);
+    }
+}

--- a/cors/cors-java/cors-java-impl/src/main/resources/application.conf
+++ b/cors/cors-java/cors-java-impl/src/main/resources/application.conf
@@ -4,3 +4,18 @@
 play.crypto.secret=whatever
 play.modules.enabled += com.lightbend.lagom.recipes.corsjava.impl.CorsjavaModule
 
+play.http.filters = "com.lightbend.lagom.recipes.corsjava.impl.MyCORSFilter"
+
+// To properly setup the CORSFilter, please refer to https://playframework.com/documentation/2.5.x/CorsFilter
+// This example is only meant to show what's required for Lagom to use CORS.
+play.filters.cors {
+  // review the values of all these settings to fulfill your needs. These values are not meant for production.
+  pathPrefixes = ["/api"]
+  allowedOrigins = null
+  allowedHttpMethods = null
+  allowedHttpHeaders = null
+  exposedHeaders = []
+  supportsCredentials = false
+  preflightMaxAge = 6 hour
+}
+

--- a/cors/cors-java/cors-java-impl/src/main/resources/application.conf
+++ b/cors/cors-java/cors-java-impl/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+#
+play.crypto.secret=whatever
+play.modules.enabled += com.lightbend.lagom.recipes.corsjava.impl.CorsjavaModule
+

--- a/cors/cors-java/project/build.properties
+++ b/cors/cors-java/project/build.properties
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2016 Lightbend Inc. <https://www.lightbend.com>
+#
+sbt.version=0.13.15

--- a/cors/cors-java/project/plugins.sbt
+++ b/cors/cors-java/project/plugins.sbt
@@ -1,0 +1,4 @@
+// The Lagom plugin
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.7")
+// Needed for importing the project into Eclipse
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")


### PR DESCRIPTION
This PR addresses https://github.com/lagom/lagom/issues/913 and innaugurates the lagom-recipes repository.

This PR is a 2-commit branch were the first commit introduces a simple lagom project and the second commit solves the actual problem. This approach exemplifies how to solve the problem at hand. The README.md in the `./cors/cors-java` folder is included in the second commit and includes: the steps to complete the implementation, the steps to run the sample and some links to further resources.

It'd be good to merge this PR without squashing (nor rebasing?) so we can refer to the actual commit that introduces the changes.