### PR TITLE
A recipee with mixed persistence in scala.

### DIFF
--- a/mixed-persistence/mixed-persistence-scala-sbt/.sbtopts
+++ b/mixed-persistence/mixed-persistence-scala-sbt/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms512M
+-J-Xmx4096M
+-J-Xss2M
+-J-XX:MaxMetaspaceSize=1024M

--- a/mixed-persistence/mixed-persistence-scala-sbt/README.md
+++ b/mixed-persistence/mixed-persistence-scala-sbt/README.md
@@ -1,0 +1,35 @@
+# Mixed Persistence Service
+
+This recipe demonstrates how to create a service in Lagom for Scala that uses Cassandra for write-side persistence and JDBC for a read-side view.
+
+## Implementation details
+
+TODO
+
+## Testing the recipe
+
+You can test this recipe using 2 separate terminals.
+
+On one terminal start the service:
+
+```
+sbt runAll
+```
+
+On a separate terminal, use `curl` to trigger some events in `HelloService`:
+
+```
+curl -H "Content-Type: application/json" -X POST -d '{"message": "Hi"}' http://localhost:9000/api/hello/Alice
+curl -H "Content-Type: application/json" -X POST -d '{"message": "Good day"}' http://localhost:9000/api/hello/Bob
+curl -H "Content-Type: application/json" -X POST -d '{"message": "Hi"}' http://localhost:9000/api/hello/Carol
+curl -H "Content-Type: application/json" -X POST -d '{"message": "Howdy"}' http://localhost:9000/api/hello/David
+```
+
+After a few seconds, use `curl` to retrieve a list of all of the stored greetings:
+
+```
+curl http://localhost:9000/api/greetings
+[{"id":"Alice","message":"Hi"},{"id":"Bob","message":"Good day"},{"id":"Carol","message":"Hi"},{"id":"David","message":"Howdy"}]
+```
+
+This is eventually consistent, so it might take a few tries before you see all of the results.

--- a/mixed-persistence/mixed-persistence-scala-sbt/build.sbt
+++ b/mixed-persistence/mixed-persistence-scala-sbt/build.sbt
@@ -7,7 +7,7 @@ scalaVersion in ThisBuild := "2.11.8"
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
 
-lazy val `hello` = (project in file("."))
+lazy val `mixed-persistence-scala-sbt` = (project in file("."))
   .aggregate(`hello-api`, `hello-impl`)
 
 lazy val `hello-api` = (project in file("hello-api"))
@@ -31,3 +31,4 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .settings(lagomForkedTestSettings: _*)
   .dependsOn(`hello-api`)
 
+lagomKafkaEnabled in ThisBuild := false

--- a/mixed-persistence/mixed-persistence-scala-sbt/build.sbt
+++ b/mixed-persistence/mixed-persistence-scala-sbt/build.sbt
@@ -1,0 +1,33 @@
+organization in ThisBuild := "com.lightbend.lagom.recipes"
+version in ThisBuild := "1.0-SNAPSHOT"
+
+// the Scala version that will be used for cross-compiled libraries
+scalaVersion in ThisBuild := "2.11.8"
+
+val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
+
+lazy val `hello` = (project in file("."))
+  .aggregate(`hello-api`, `hello-impl`)
+
+lazy val `hello-api` = (project in file("hello-api"))
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslApi
+    )
+  )
+
+lazy val `hello-impl` = (project in file("hello-impl"))
+  .enablePlugins(LagomScala)
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslPersistenceCassandra,
+      lagomScaladslPersistenceJdbc,
+      lagomScaladslTestKit,
+      macwire,
+      scalaTest
+    )
+  )
+  .settings(lagomForkedTestSettings: _*)
+  .dependsOn(`hello-api`)
+

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-api/src/main/scala/com/lightbend/lagom/recipes/hello/api/HelloService.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-api/src/main/scala/com/lightbend/lagom/recipes/hello/api/HelloService.scala
@@ -7,19 +7,35 @@ import play.api.libs.json.{ Format, Json }
 trait HelloService extends Service {
 
   def hello(id: String): ServiceCall[NotUsed, String]
+
   def useGreeting(id: String): ServiceCall[GreetingMessage, Done]
+
+  def allGreetings(): ServiceCall[NotUsed, Seq[Greeting]]
 
   override final def descriptor = {
     import Service._
     named("hello")
       .withCalls(
         pathCall("/api/hello/:id", hello _),
-        pathCall("/api/hello/:id", useGreeting _)
+        pathCall("/api/hello/:id", useGreeting _),
+        pathCall("/api/greetings", allGreetings _)
       )
       .withAutoAcl(true)
   }
 }
 
+/**
+  * The Greeting is both the message and the person that message is meant for.
+  */
+case class Greeting(name: String, message: String)
+
+object Greeting {
+  implicit val format: Format[Greeting] = Json.format
+}
+
+/**
+  * This class only models the message of a Greeting
+  */
 case class GreetingMessage(message: String)
 
 object GreetingMessage {

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-api/src/main/scala/com/lightbend/lagom/recipes/hello/api/HelloService.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-api/src/main/scala/com/lightbend/lagom/recipes/hello/api/HelloService.scala
@@ -1,0 +1,27 @@
+package com.lightbend.lagom.recipes.hello.api
+
+import akka.{ Done, NotUsed }
+import com.lightbend.lagom.scaladsl.api.{ Service, ServiceCall }
+import play.api.libs.json.{ Format, Json }
+
+trait HelloService extends Service {
+
+  def hello(id: String): ServiceCall[NotUsed, String]
+  def useGreeting(id: String): ServiceCall[GreetingMessage, Done]
+
+  override final def descriptor = {
+    import Service._
+    named("hello")
+      .withCalls(
+        pathCall("/api/hello/:id", hello _),
+        pathCall("/api/hello/:id", useGreeting _)
+      )
+      .withAutoAcl(true)
+  }
+}
+
+case class GreetingMessage(message: String)
+
+object GreetingMessage {
+  implicit val format: Format[GreetingMessage] = Json.format[GreetingMessage]
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
@@ -1,0 +1,9 @@
+#
+#
+play.crypto.secret = whatever
+play.application.loader = com.lightbend.lagom.recipes.hello.impl.HelloLoader
+
+hello.cassandra.keyspace = hello
+
+cassandra-journal.keyspace = ${hello.cassandra.keyspace}
+cassandra-snapshot-store.keyspace = ${hello.cassandra.keyspace}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
@@ -7,3 +7,12 @@ hello.cassandra.keyspace = hello
 
 cassandra-journal.keyspace = ${hello.cassandra.keyspace}
 cassandra-snapshot-store.keyspace = ${hello.cassandra.keyspace}
+
+
+# JPA read-side configuration.
+db.default {
+  driver = "org.h2.Driver"
+  url = "jdbc:h2:mem:hello-service"
+}
+
+jdbc-defaults.slick.driver = "slick.driver.H2Driver$"

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloEntity.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloEntity.scala
@@ -73,7 +73,6 @@ class HelloEntity extends PersistentEntity {
         // We simply update the current state to use the greeting message from
         // the event.
         HelloState(newMessage, LocalDateTime.now().toString)
-
     }
   }
 }

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloEntity.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloEntity.scala
@@ -1,0 +1,191 @@
+package com.lightbend.lagom.recipes.hello.impl
+
+import java.time.LocalDateTime
+
+import akka.Done
+import com.lightbend.lagom.scaladsl.persistence.{AggregateEvent, AggregateEventTag, PersistentEntity}
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
+import com.lightbend.lagom.scaladsl.playjson.{JsonSerializer, JsonSerializerRegistry}
+import play.api.libs.json.{Format, Json}
+
+import scala.collection.immutable.Seq
+
+/**
+  * This is an event sourced entity. It has a state, [[HelloState]], which
+  * stores what the greeting should be (eg, "Hello").
+  *
+  * Event sourced entities are interacted with by sending them commands. This
+  * entity supports two commands, a [[UseGreetingMessage]] command, which is
+  * used to change the greeting, and a [[Hello]] command, which is a read
+  * only command which returns a greeting to the name specified by the command.
+  *
+  * Commands get translated to events, and it's the events that get persisted by
+  * the entity. Each event will have an event handler registered for it, and an
+  * event handler simply applies an event to the current state. This will be done
+  * when the event is first created, and it will also be done when the entity is
+  * loaded from the database - each event will be replayed to recreate the state
+  * of the entity.
+  *
+  * This entity defines one event, the [[GreetingMessageChanged]] event,
+  * which is emitted when a [[UseGreetingMessage]] command is received.
+  */
+class HelloEntity extends PersistentEntity {
+
+  override type Command = HelloCommand[_]
+  override type Event = HelloEvent
+  override type State = HelloState
+
+  /**
+    * The initial state. This is used if there is no snapshotted state to be found.
+    */
+  override def initialState: HelloState = HelloState("Hello", LocalDateTime.now.toString)
+
+  /**
+    * An entity can define different behaviours for different states, so the behaviour
+    * is a function of the current state to a set of actions.
+    */
+  override def behavior: Behavior = {
+    case HelloState(message, _) => Actions().onCommand[UseGreetingMessage, Done] {
+
+      // Command handler for the UseGreetingMessage command
+      case (UseGreetingMessage(newMessage), ctx, state) =>
+        // In response to this command, we want to first persist it as a
+        // GreetingMessageChanged event
+        ctx.thenPersist(
+          GreetingMessageChanged(newMessage)
+        ) { _ =>
+          // Then once the event is successfully persisted, we respond with done.
+          ctx.reply(Done)
+        }
+
+    }.onReadOnlyCommand[Hello, String] {
+
+      // Command handler for the Hello command
+      case (Hello(name), ctx, state) =>
+        // Reply with a message built from the current message, and the name of
+        // the person we're meant to say hello to.
+        ctx.reply(s"$message, $name!")
+
+    }.onEvent {
+
+      // Event handler for the GreetingMessageChanged event
+      case (GreetingMessageChanged(newMessage), state) =>
+        // We simply update the current state to use the greeting message from
+        // the event.
+        HelloState(newMessage, LocalDateTime.now().toString)
+
+    }
+  }
+}
+
+/**
+  * The current state held by the persistent entity.
+  */
+case class HelloState(message: String, timestamp: String)
+
+object HelloState {
+  /**
+    * Format for the hello state.
+    *
+    * Persisted entities get snapshotted every configured number of events. This
+    * means the state gets stored to the database, so that when the entity gets
+    * loaded, you don't need to replay all the events, just the ones since the
+    * snapshot. Hence, a JSON format needs to be declared so that it can be
+    * serialized and deserialized when storing to and from the database.
+    */
+  implicit val format: Format[HelloState] = Json.format
+}
+
+/**
+  * This interface defines all the events that the HelloEntity supports.
+  */
+sealed trait HelloEvent extends AggregateEvent[HelloEvent] {
+  def aggregateTag = HelloEvent.Tag
+}
+
+object HelloEvent {
+  val Tag = AggregateEventTag[HelloEvent]
+}
+
+/**
+  * An event that represents a change in greeting message.
+  */
+case class GreetingMessageChanged(message: String) extends HelloEvent
+
+object GreetingMessageChanged {
+
+  /**
+    * Format for the greeting message changed event.
+    *
+    * Events get stored and loaded from the database, hence a JSON format
+    * needs to be declared so that they can be serialized and deserialized.
+    */
+  implicit val format: Format[GreetingMessageChanged] = Json.format
+}
+
+/**
+  * This interface defines all the commands that the HelloWorld entity supports.
+  */
+sealed trait HelloCommand[R] extends ReplyType[R]
+
+/**
+  * A command to switch the greeting message.
+  *
+  * It has a reply type of [[Done]], which is sent back to the caller
+  * when all the events emitted by this command are successfully persisted.
+  */
+case class UseGreetingMessage(message: String) extends HelloCommand[Done]
+
+object UseGreetingMessage {
+
+  /**
+    * Format for the use greeting message command.
+    *
+    * Persistent entities get sharded across the cluster. This means commands
+    * may be sent over the network to the node where the entity lives if the
+    * entity is not on the same node that the command was issued from. To do
+    * that, a JSON format needs to be declared so the command can be serialized
+    * and deserialized.
+    */
+  implicit val format: Format[UseGreetingMessage] = Json.format
+}
+
+/**
+  * A command to say hello to someone using the current greeting message.
+  *
+  * The reply type is String, and will contain the message to say to that
+  * person.
+  */
+case class Hello(name: String) extends HelloCommand[String]
+
+object Hello {
+
+  /**
+    * Format for the hello command.
+    *
+    * Persistent entities get sharded across the cluster. This means commands
+    * may be sent over the network to the node where the entity lives if the
+    * entity is not on the same node that the command was issued from. To do
+    * that, a JSON format needs to be declared so the command can be serialized
+    * and deserialized.
+    */
+  implicit val format: Format[Hello] = Json.format
+}
+
+/**
+  * Akka serialization, used by both persistence and remoting, needs to have
+  * serializers registered for every type serialized or deserialized. While it's
+  * possible to use any serializer you want for Akka messages, out of the box
+  * Lagom provides support for JSON, via this registry abstraction.
+  *
+  * The serializers are registered here, and then provided to Lagom in the
+  * application loader.
+  */
+object HelloSerializerRegistry extends JsonSerializerRegistry {
+  override def serializers: Seq[JsonSerializer[_]] = Seq(
+    JsonSerializer[UseGreetingMessage],
+    JsonSerializer[Hello],
+    JsonSerializer[GreetingMessageChanged],
+    JsonSerializer[HelloState]
+  )
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloLoader.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloLoader.scala
@@ -1,0 +1,33 @@
+package com.lightbend.lagom.recipes.hello.impl
+
+import com.lightbend.lagom.recipes.hello.api.HelloService
+import com.lightbend.lagom.scaladsl.api.ServiceLocator
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import com.lightbend.lagom.scaladsl.persistence.cassandra.WriteSideCassandraPersistenceComponents
+import com.lightbend.lagom.scaladsl.server._
+import com.softwaremill.macwire._
+import play.api.libs.ws.ahc.AhcWSComponents
+
+class HelloLoader extends LagomApplicationLoader {
+
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new HelloApplication(context) {
+      override def serviceLocator: ServiceLocator = NoServiceLocator
+    }
+
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new HelloApplication(context) with LagomDevModeComponents
+
+  override def describeService = Some(readDescriptor[HelloService])
+}
+
+abstract class HelloApplication(context: LagomApplicationContext)
+  extends LagomApplication(context)
+    with WriteSideCassandraPersistenceComponents
+    with AhcWSComponents {
+
+  override lazy val lagomServer = serverFor[HelloService](wire[HelloServiceImpl])
+  override lazy val jsonSerializerRegistry = HelloSerializerRegistry
+  persistentEntityRegistry.register(wire[HelloEntity])
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloLoader.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloLoader.scala
@@ -1,12 +1,15 @@
 package com.lightbend.lagom.recipes.hello.impl
 
 import com.lightbend.lagom.recipes.hello.api.HelloService
+import com.lightbend.lagom.recipes.hello.impl.readside.{ GreetingsEventProcessor, GreetingsRepository }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import com.lightbend.lagom.scaladsl.persistence.cassandra.WriteSideCassandraPersistenceComponents
+import com.lightbend.lagom.scaladsl.persistence.jdbc.ReadSideJdbcPersistenceComponents
 import com.lightbend.lagom.scaladsl.server._
 import com.softwaremill.macwire._
+import play.api.db.HikariCPComponents
 import play.api.libs.ws.ahc.AhcWSComponents
 
 class HelloLoader extends LagomApplicationLoader {
@@ -24,10 +27,24 @@ class HelloLoader extends LagomApplicationLoader {
 
 abstract class HelloApplication(context: LagomApplicationContext)
   extends LagomApplication(context)
+    // Mix in the JDBC read-side
+    with ReadSideJdbcPersistenceComponents
+    // A connection pool is required any time we mix in a JDBC-based persistence Component (like
+    // the read-side above)
+    with HikariCPComponents
+    // Mixing in WriteSideCassandraPersistenceComponents instead of CassandraPersistenceComponents
+    // we can control what read-side to mix in
     with WriteSideCassandraPersistenceComponents
     with AhcWSComponents {
 
   override lazy val lagomServer = serverFor[HelloService](wire[HelloServiceImpl])
+
   override lazy val jsonSerializerRegistry = HelloSerializerRegistry
+
+  lazy val eventProcessor = wire[GreetingsEventProcessor]
+  lazy val repo = wire[GreetingsRepository]
+
+
+
   persistentEntityRegistry.register(wire[HelloEntity])
 }

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloServiceImpl.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/HelloServiceImpl.scala
@@ -1,0 +1,19 @@
+package com.lightbend.lagom.recipes.hello.impl
+
+import com.lightbend.lagom.recipes.hello.api.HelloService
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntityRegistry
+
+class HelloServiceImpl(persistentEntityRegistry: PersistentEntityRegistry) extends HelloService {
+
+  override def hello(id: String) = ServiceCall { _ =>
+    val ref = persistentEntityRegistry.refFor[HelloEntity](id)
+    ref.ask(Hello(id))
+  }
+
+  override def useGreeting(id: String) = ServiceCall { request =>
+    val ref = persistentEntityRegistry.refFor[HelloEntity](id)
+    ref.ask(UseGreetingMessage(request.message))
+  }
+
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/readside/GreetingsRepository.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/scala/com/lightbend/lagom/recipes/hello/impl/readside/GreetingsRepository.scala
@@ -1,0 +1,85 @@
+package com.lightbend.lagom.recipes.hello.impl.readside
+
+import java.sql.{ Connection, ResultSet }
+
+import com.lightbend.lagom.recipes.hello.impl.{ GreetingMessageChanged, HelloEvent }
+import com.lightbend.lagom.scaladsl.persistence.jdbc.JdbcSession.tryWith
+import com.lightbend.lagom.scaladsl.persistence.jdbc.{ JdbcReadSide, JdbcSession }
+import com.lightbend.lagom.scaladsl.persistence.{ AggregateEventTag, EventStreamElement, ReadSide, ReadSideProcessor }
+
+import scala.collection.immutable.Seq
+import scala.collection.mutable
+import scala.concurrent.{ ExecutionContext, Future }
+
+case class ReadSideGreeting(name: String, message: String)
+
+class GreetingsRepository(
+                           session: JdbcSession,
+                           readSide: ReadSide,
+                           eventProcessor: GreetingsEventProcessor
+                         )(
+                           implicit ec: ExecutionContext
+                         ) {
+
+  readSide.register(eventProcessor)
+
+  def getAll(): Future[Seq[ReadSideGreeting]] = {
+    session.withConnection { conn: Connection =>
+      tryWith(conn.prepareStatement("SELECT * from greetings;").executeQuery) {
+        parse
+      }
+    }
+  }
+
+  private def parse(rs: ResultSet): Seq[ReadSideGreeting] = {
+    val greetings = mutable.Buffer.empty[ReadSideGreeting]
+    while (rs.next()) {
+      greetings += ReadSideGreeting(
+        rs.getString("name"),
+        rs.getString("message")
+      )
+    }
+    greetings.toIndexedSeq
+  }
+
+}
+
+
+class GreetingsEventProcessor(readSide: JdbcReadSide)(implicit ec: ExecutionContext)
+  extends ReadSideProcessor[HelloEvent] {
+
+  val createTableSql =
+    "CREATE TABLE IF NOT EXISTS PUBLIC.greetings (name NVARCHAR2(64), message NVARCHAR2(512), PRIMARY KEY(name))"
+
+  // This is a convenience for creating the read-side table in development mode.
+  val buildTables: Connection => Unit = { connection =>
+    JdbcSession.tryWith(connection.createStatement()) {
+      _.executeUpdate(createTableSql)
+    }
+  }
+
+  val processGreetingMessageChanged: (Connection, EventStreamElement[GreetingMessageChanged]) => Unit = {
+    (connection, eventElement) =>
+      JdbcSession.tryWith(
+        // "MERGE" is H2's equivalent to 'INSERT OR UPDATE'.
+        // See http://www.h2database.com/html/grammar.html#merge
+        // We use "MERGE" here because we want this read-side to keep only the lastest message per each name
+        // Since 'name' is the table Primary Key then merging is trivial.
+        connection.prepareStatement("MERGE INTO greetings (name, message) VALUES (?, ?)")
+      ) { statement =>
+        statement.setString(1, eventElement.entityId)
+        statement.setString(2, eventElement.event.message)
+        statement.executeUpdate()
+      }
+  }
+
+  override def buildHandler() =
+    readSide
+      .builder[HelloEvent]("GreetingsReadSide")
+      .setGlobalPrepare(buildTables)
+      .setEventHandler(processGreetingMessageChanged)
+      .build()
+
+  override def aggregateTags: Set[AggregateEventTag[HelloEvent]] = Set(HelloEvent.Tag)
+
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/test/resources/logback.xml
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.cassandra" level="ERROR" />
+    <logger name="com.datastax.driver" level="WARN" />
+
+    <logger name="akka" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/test/scala/com/lightbend/lagom/recipes/hello/impl/HelloServiceSpec.scala
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/test/scala/com/lightbend/lagom/recipes/hello/impl/HelloServiceSpec.scala
@@ -1,0 +1,38 @@
+package com.lightbend.lagom.recipes.hello.impl
+
+import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
+import com.lightbend.lagom.scaladsl.testkit.ServiceTest
+import org.scalatest.{AsyncWordSpec, BeforeAndAfterAll, Matchers}
+import com.lightbend.lagom.recipes.hello.api._
+
+class HelloServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll {
+
+  private val server = ServiceTest.startServer(
+    ServiceTest.defaultSetup
+      .withCassandra(true)
+  ) { ctx =>
+    new HelloApplication(ctx) with LocalServiceLocator
+  }
+
+  val client = server.serviceClient.implement[HelloService]
+
+  override protected def afterAll() = server.stop()
+
+  "Hello service" should {
+
+    "say hello" in {
+      client.hello("Alice").invoke().map { answer =>
+        answer should ===("Hello, Alice!")
+      }
+    }
+
+    "allow responding with a custom message" in {
+      for {
+        _ <- client.useGreeting("Bob").invoke(GreetingMessage("Hi"))
+        answer <- client.hello("Bob").invoke()
+      } yield {
+        answer should ===("Hi, Bob!")
+      }
+    }
+  }
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/project/build.properties
+++ b/mixed-persistence/mixed-persistence-scala-sbt/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/mixed-persistence/mixed-persistence-scala-sbt/project/plugins.sbt
+++ b/mixed-persistence/mixed-persistence-scala-sbt/project/plugins.sbt
@@ -1,0 +1,4 @@
+// The Lagom plugin
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.10")
+// Needed for importing the project into Eclipse
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")


### PR DESCRIPTION
Demontrate a mixed persistence service where write-side uses C* and read-side uses JDBC. 

This is the scala equivalent of `mixed-persistence-java-sbt`