### PR TITLE
Add explicit Akka Persistence plugin configuration

### DIFF
--- a/mixed-persistence/mixed-persistence-java-sbt/hello-impl/src/main/resources/application.conf
+++ b/mixed-persistence/mixed-persistence-java-sbt/hello-impl/src/main/resources/application.conf
@@ -21,3 +21,16 @@ db.default {
 }
 
 jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"
+
+# Finally, ensure that Cassandra is used for the journal and snapshot-store
+# Lagom's Cassandra and JDBC persistence modules both define these properties,
+# so the order they are applied is non-deterministic.
+akka.persistence {
+  journal {
+    plugin = cassandra-journal
+  }
+
+  snapshot-store {
+    plugin = cassandra-snapshot-store
+  }
+}

--- a/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
+++ b/mixed-persistence/mixed-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
@@ -1,17 +1,29 @@
-#
-#
 play.application.loader = com.lightbend.lagom.recipes.hello.impl.HelloLoader
 
+# Cassandra write-side configuration.
 hello.cassandra.keyspace = hello
 
 cassandra-journal.keyspace = ${hello.cassandra.keyspace}
 cassandra-snapshot-store.keyspace = ${hello.cassandra.keyspace}
 
 
-# JPA read-side configuration.
+# JDBC read-side configuration.
 db.default {
   driver = "org.h2.Driver"
   url = "jdbc:h2:mem:hello-service"
 }
 
 jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"
+
+# Finally, ensure that Cassandra is used for the journal and snapshot-store
+# Lagom's Cassandra and JDBC persistence modules both define these properties,
+# so the order they are applied is non-deterministic.
+akka.persistence {
+  journal {
+    plugin = cassandra-journal
+  }
+
+  snapshot-store {
+    plugin = cassandra-snapshot-store
+  }
+}


### PR DESCRIPTION
Lagom's Cassandra and JDBC persistence modules both define these properties in reference-overrides.conf. The order they are applied is non-deterministic. This resolves the ambiguity.

See https://github.com/lagom/lagom/issues/1199