### PR TITLE
[DO NOT MERGE] appending different play routers to lagom server

### DIFF
--- a/file-upload/file-upload-scala-sbt/build.sbt
+++ b/file-upload/file-upload-scala-sbt/build.sbt
@@ -26,7 +26,10 @@ lazy val `fileupload-impl` = (project in file("fileupload-impl"))
   .settings(
     libraryDependencies ++= Seq(
       lagomScaladslTestKit,
+      lagomScaladslCluster,
       macwire,
+      "com.lightbend.akka.management" %% "akka-management"              % "0.15.0",
+      "com.lightbend.akka.management" %% "akka-management-cluster-http" % "0.15.0",
       scalaTest
     )
   )

--- a/file-upload/file-upload-scala-sbt/fileupload-api/src/main/scala/com/example/fileupload/api/FileuploadService.scala
+++ b/file-upload/file-upload-scala-sbt/fileupload-api/src/main/scala/com/example/fileupload/api/FileuploadService.scala
@@ -23,8 +23,10 @@ trait FileUploadService extends Service {
         pathCall("/api/echo", uppercaseEcho _)
       )
       .withAcls(
-        ServiceAcl(pathRegex = Some("/api/echo")),
-        ServiceAcl(pathRegex = Some("/api/files"))
+        ServiceAcl.forPathRegex("/api/echo"),
+        ServiceAcl.forPathRegex("/api/files"),
+        ServiceAcl.forPathRegex("/cluster/members*"),
+        ServiceAcl.forPathRegex("/cluster/shards*")
       )
   }
 }

--- a/file-upload/file-upload-scala-sbt/fileupload-impl/src/main/resources/routes
+++ b/file-upload/file-upload-scala-sbt/fileupload-impl/src/main/resources/routes
@@ -1,3 +1,2 @@
 
 POST    /api/files      com.example.play.controllers.FileUploadController.uploadFile()
-->      /               com.lightbend.lagom.scaladsl.server.LagomServiceRouter

--- a/file-upload/file-upload-scala-sbt/fileupload-impl/src/main/scala/com/example/fileupload/impl/FileuploadLoader.scala
+++ b/file-upload/file-upload-scala-sbt/fileupload-impl/src/main/scala/com/example/fileupload/impl/FileuploadLoader.scala
@@ -1,13 +1,18 @@
 package com.example.fileupload.impl
 
+import akka.cluster.Cluster
+import akka.management.cluster.ClusterHttpManagementRoutes
 import com.example.fileupload.api.FileUploadService
 import com.example.play.controllers.FileUploadController
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.cluster.ClusterComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import com.lightbend.lagom.scaladsl.playjson.{EmptyJsonSerializerRegistry, JsonSerializerRegistry}
 import com.lightbend.lagom.scaladsl.server._
 import com.softwaremill.macwire._
 import play.api.libs.ws.ahc.AhcWSComponents
+import play.api.routing.AkkaHttpPlayRouter
 import router.Routes
 
 class FileUploadLoader extends LagomApplicationLoader {
@@ -15,6 +20,7 @@ class FileUploadLoader extends LagomApplicationLoader {
   override def load(context: LagomApplicationContext): LagomApplication =
     new FileUploadApplication(context) {
       override def serviceLocator: ServiceLocator = NoServiceLocator
+
     }
 
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
@@ -25,32 +31,26 @@ class FileUploadLoader extends LagomApplicationLoader {
 
 abstract class FileUploadApplication(context: LagomApplicationContext)
   extends LagomApplication(context)
+    with ClusterComponents
     with AhcWSComponents {
 
-  // Bind the service that this server provides
-  override lazy val lagomServer = serverFor[FileUploadService](wire[FileUploadServiceImpl])
+  override def jsonSerializerRegistry: JsonSerializerRegistry = EmptyJsonSerializerRegistry
 
+  lazy implicit val ac = actorSystem
+  lazy val clusterHttpRouter = AkkaHttpPlayRouter("/cluster", ClusterHttpManagementRoutes(Cluster(ac)))
 
-  // We override the default `router` Lagom builds from the user-provided
-  // `lagomServer`. The new Router is actually an instance of the result
-  // of compiling the `routes` file in `src/main/resources`.
-  //
-  // The router is built using an httpErrorHandler and a list of Routes.
-  // the list of Routes depends on the contents of the `src/main/resources/routes`
-  // file. In our case, the `src/main/resources/routes` declares:
-  //
-  //  POST    /api/files      com.example.play.controllers.FileUploadController.uploadFile()
-  //  ->      /               com.lightbend.lagom.scaladsl.server.LagomServiceRouter
-  //
-  // which translates into `new Routes(...)` needing an instance of a
-  // FileUploadController and an instance of the default lagom router.
-  //
-  // This is a Play provided feature. To know more, see:
-  //     https://www.playframework.com/documentation/2.6.x/ScalaCompileTimeDependencyInjection#Providing-a-router
-  override lazy val router = new Routes(
+  lazy val fileUploadRouter = new Routes(
     httpErrorHandler,
-    new FileUploadController(controllerComponents),
-    lagomServer.router
+    new FileUploadController(controllerComponents)
   )
+
+  // Bind the service that this server provides
+  override lazy val lagomServer: LagomServer =
+    serverFor[FileUploadService](wire[FileUploadServiceImpl])
+      .plusRouter(clusterHttpRouter)
+      .plusRouter(fileUploadRouter.withPrefix("/io"))
+
+
+
 
 }

--- a/file-upload/file-upload-scala-sbt/fileupload-impl/src/main/scala/play/api/routing/AkkaHttpPlayRouter.scala
+++ b/file-upload/file-upload-scala-sbt/fileupload-impl/src/main/scala/play/api/routing/AkkaHttpPlayRouter.scala
@@ -1,0 +1,33 @@
+package play.api.routing
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.server.{Route, RoutingLog}
+import akka.http.scaladsl.settings.{ParserSettings, RoutingSettings}
+import akka.stream.{ActorMaterializerHelper, Materializer}
+import play.api.mvc.akkahttp.AkkaHttpHandler
+import play.api.routing.Router.Routes
+
+import scala.concurrent.Future
+
+object AkkaHttpPlayRouter {
+
+  def apply(prefix: String, akkaHttpRoute: Route)(implicit actorSystem: ActorSystem, materializer: Materializer): Router = {
+    val routingSettings = RoutingSettings(actorSystem)
+    val routingLog = RoutingLog.fromActorSystem(actorSystem)
+    val parserSettings = ParserSettings(actorSystem)
+    apply(prefix, Route.asyncHandler(akkaHttpRoute)(routingSettings, parserSettings, materializer, routingLog))
+  }
+
+
+  def apply(prefix: String, handler: HttpRequest => Future[HttpResponse]): Router = {
+
+    new SimpleRouter {
+      val akkaHttpHandler = new AkkaHttpHandler {
+        override def apply(request: HttpRequest): Future[HttpResponse] = handler(request)
+      }
+      override def routes: Routes = { case _ => akkaHttpHandler }
+    }.withPrefix(prefix)
+  }
+
+}

--- a/file-upload/file-upload-scala-sbt/fileupload-impl/src/test/scala/com/example/fileupload/impl/FileuploadServiceSpec.scala
+++ b/file-upload/file-upload-scala-sbt/fileupload-impl/src/test/scala/com/example/fileupload/impl/FileuploadServiceSpec.scala
@@ -40,6 +40,14 @@ class FileUploadServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAf
       }
 
     }
+
+    "respond to cluster management request under /cluster/members" in {
+      val eventualResponse = ws
+          .url(server.playServer.httpPort.map { port => s"http://localhost:$port/cluster/members" }.get)
+          .get()
+      eventualResponse.map{ _.status shouldBe 200 }
+    }
+
     "handle file uploads " in {
 
       // Create a java.nio.file.Path to the file we want to upload
@@ -62,7 +70,7 @@ class FileUploadServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAf
 
       val eventualResponse =
         ws
-          .url(server.playServer.httpPort.map { port => s"http://localhost:$port/api/files" }.get)
+          .url(server.playServer.httpPort.map { port => s"http://localhost:$port/io/api/files" }.get)
           .post(Source(multipartFormParts))
 
 

--- a/file-upload/file-upload-scala-sbt/project/plugins.sbt
+++ b/file-upload/file-upload-scala-sbt/project/plugins.sbt
@@ -1,4 +1,4 @@
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.4")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M1")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")


### PR DESCRIPTION
This PR demonstrates how we can add additional Play routers on an exiting Lagom server. 

This PR won't compile because it depends on Lagom 1.5.0-M1 which doesn't exist yet. 
To really run it, one need to check https://github.com/lagom/lagom/pull/1440, merge https://github.com/lagom/lagom/pull/1405 into it and build a local version.