### PR TITLE
Fix mixed-persistence-java-sbt tests

### DIFF
--- a/mixed-persistence/mixed-persistence-java-sbt/build.sbt
+++ b/mixed-persistence/mixed-persistence-java-sbt/build.sbt
@@ -27,7 +27,6 @@ lazy val `hello-impl` = (project in file("hello-impl"))
     libraryDependencies ++= Seq(
       lagomJavadslPersistenceCassandra,
       lagomJavadslPersistenceJpa,
-      lagomJavadslKafkaBroker,
       lagomJavadslTestKit,
       lombok,
       h2,
@@ -42,3 +41,4 @@ def common = Seq(
   javacOptions in compile += "-parameters"
 )
 
+lagomKafkaEnabled in ThisBuild := false

--- a/mixed-persistence/mixed-persistence-java-sbt/project/plugins.sbt
+++ b/mixed-persistence/mixed-persistence-java-sbt/project/plugins.sbt
@@ -1,4 +1,4 @@
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.4")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.6")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")


### PR DESCRIPTION
- Update Lagom to 1.4.6

  This includes the fix for lagom/lagom#1351, which was causing the tests in this project to fail.

- Remove unused Kafka dependency and disable running Kafka in development.

  This is unused in the recipe, and brought in a transitive dependency on log4j, which triggered some spurious errors in the output due to Hibernate choosing to use log4j over slf4j when it is on the classpath.
